### PR TITLE
Widen the Forge E2E QA command budget

### DIFF
--- a/scripts/run-forge-e2e-tests.mjs
+++ b/scripts/run-forge-e2e-tests.mjs
@@ -28,7 +28,11 @@ const env = {
   FORGE_MAX_REPAIR_ATTEMPTS: "10",
   FORGE_E2E_CONTROLLED_QA: "true",
   FORGE_DISABLE_AUTO_REPAIR: "true",
-  FORGE_QA_COMMAND_TIMEOUT_MS: "300000",
+  // A cold `npm install` for a freshly generated Next.js site regularly exceeds five minutes
+  // on a developer machine (Windows filesystem plus on-access scanning), which fails the QA
+  // install check for environment reasons rather than a defect in the generated site. Give the
+  // harness a wider budget than the product default; the E2E client timeout derives from this.
+  FORGE_QA_COMMAND_TIMEOUT_MS: process.env.FORGE_QA_COMMAND_TIMEOUT_MS ?? "900000",
   FORGE_E2E_BASE_URL: "http://127.0.0.1:3301",
 }
 let server


### PR DESCRIPTION
The QA install check failed with "Command timed out" after five minutes. A cold npm install for a freshly generated Next.js site regularly exceeds that on a developer machine (Windows filesystem plus on-access scanning), so the failure was environmental rather than a defect in the generated site: the other twelve QA checks passed, including SEO 100/AEO 90/GEO 100 and full content-depth and design-alignment checks.

Raise the harness budget to fifteen minutes and allow an override. The product default is unchanged, and the E2E client timeout already derives from this value so the two cannot drift apart.

Full suite now passes end to end: 20 workflow stages including the deliberate copy rejection and regeneration cycle, QA repair, proposal generation and quality approval, with 11 durable jobs executed.

## Summary

- 

## Type

- [ ] `feat`
- [ ] `fix`
- [ ] `test`
- [ ] `docs`
- [ ] `refactor`
- [ ] `security`
- [ ] `perf`
- [ ] `chore`

## Scope

- [ ] Public web
- [ ] Admin
- [ ] Forge
- [ ] Database/migrations
- [ ] Docker/deployment/Nginx
- [ ] CI/tooling
- [ ] Documentation only

## Definition of Done

- [ ] Existing behaviour and security boundaries are preserved.
- [ ] User-facing errors are safe; internal diagnostics stay server-side.
- [ ] Tests were added or updated where appropriate.
- [ ] Migrations/env/deployment/docs were updated where applicable.
- [ ] Residual risks and manual QA steps are listed below.

## Validation

Commands run:

```text

```

Commands not run and why:

```text

```

## Migrations and Env

- [ ] No database migration.
- [ ] Migration included and documented.
- [ ] No new environment variables.
- [ ] Environment variables added to `.env.example` and docs.

Migration order or rollout notes:

```text

```

## Security and Privacy

- [ ] No secrets, raw provider credentials, real `.env` files, database dumps, or client-private exports are included.
- [ ] No generated workspace is exposed publicly.
- [ ] Admin/Forge access control is preserved.
- [ ] Public analytics or tracking remains minimised and consent-aware.

Security notes:

```text

```

## Screenshots or Evidence

Add screenshots, logs, traces, or links when the change is visual, operational, or workflow-heavy.

## Follow-up

- 
