### PR TITLE
fix: make setup-node caching explicit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,6 +360,7 @@ jobs:
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 22
+          package-manager-cache: false
 
       - name: Use supported npm
         run: npm install --global npm@10.9.2
@@ -402,6 +403,7 @@ jobs:
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 22
+          package-manager-cache: false
 
       - name: Use supported npm
         run: npm install --global npm@10.9.2
@@ -456,6 +458,7 @@ jobs:
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 22
+          package-manager-cache: false
 
       - name: Use supported npm
         run: npm install --global npm@10.9.2
@@ -480,6 +483,7 @@ jobs:
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 22
+          package-manager-cache: false
 
       - name: Use supported npm
         run: npm install --global npm@10.9.2
@@ -503,7 +507,9 @@ jobs:
         with:
           node-version: 22
           cache: npm
-          cache-dependency-path: admin/package-lock.json
+          cache-dependency-path: |
+            web/package-lock.json
+            admin/package-lock.json
 
       - name: Use supported npm
         run: npm install --global npm@10.9.2

--- a/scripts/check-github-actions.mjs
+++ b/scripts/check-github-actions.mjs
@@ -63,6 +63,10 @@ export function validateWorkflowSet(workflows, repositoryRoot) {
   const failures = []
   const byName = new Map(workflows.map((workflow) => [workflow.name, workflow.content]))
 
+  if (existsSync(path.join(repositoryRoot, "package-lock.json"))) {
+    failures.push("[root-lockfile] the repository must not contain a root package-lock.json")
+  }
+
   for (const name of REQUIRED_WORKFLOWS) {
     const content = byName.get(name)
     if (!content) {
@@ -94,6 +98,7 @@ export function validateWorkflowSet(workflows, repositoryRoot) {
       if (!/^\s{4}timeout-minutes:\s*\d+\s*$/m.test(job.content)) {
         failures.push(`[timeout] ${name} job ${job.name} has no timeout-minutes`)
       }
+      failures.push(...validateSetupNodeCaching(job.content, repositoryRoot, `${name} job ${job.name}`))
     }
   }
 
@@ -156,6 +161,42 @@ export function validateWorkflowSet(workflows, repositoryRoot) {
   return failures
 }
 
+export function validateSetupNodeCaching(jobContent, repositoryRoot, label = "workflow job") {
+  const failures = []
+  const setupBlocks = jobContent
+    .split(/(?=^\s*- name:)/m)
+    .filter((step) => step.includes("actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38"))
+  if (!setupBlocks.length) return failures
+
+  const needsWeb = /working-directory:[ \t]*web[ \t]*$/m.test(jobContent) || /npm\s+--prefix\s+web\s+(?:ci|install)\b/.test(jobContent)
+  const needsAdmin = /working-directory:[ \t]*admin[ \t]*$/m.test(jobContent) || /npm\s+--prefix\s+admin\s+(?:ci|install)\b/.test(jobContent)
+  const matrixApps = /app:\s*\[\s*web\s*,\s*admin\s*\]/.test(jobContent)
+
+  for (const block of setupBlocks) {
+    const disabled = /^\s*package-manager-cache:\s*false\s*$/m.test(block)
+    const npmCache = /^\s*cache:\s*["']?npm["']?\s*$/m.test(block)
+    const paths = cacheDependencyPaths(block)
+    if (disabled) {
+      if (npmCache || paths.length) failures.push(`[setup-node-cache] ${label} mixes disabled and enabled caching`)
+      if (needsWeb || needsAdmin || matrixApps) failures.push(`[setup-node-cache] ${label} disables caching for an application dependency install`)
+      continue
+    }
+    if (!npmCache) failures.push(`[setup-node-cache] ${label} relies on setup-node automatic package-manager caching`)
+    if (!paths.length) failures.push(`[setup-node-cache-path] ${label} enables npm caching without an explicit cache-dependency-path`)
+    const hasWeb = paths.includes("web/package-lock.json")
+    const hasAdmin = paths.includes("admin/package-lock.json")
+    const hasMatrix = paths.includes("${{ matrix.app }}/package-lock.json")
+    if ((needsWeb || matrixApps) && !hasWeb && !hasMatrix) failures.push(`[setup-node-cache-path] ${label} must cache web/package-lock.json`)
+    if ((needsAdmin || matrixApps) && !hasAdmin && !hasMatrix) failures.push(`[setup-node-cache-path] ${label} must cache admin/package-lock.json`)
+    for (const cachePath of paths) {
+      if (cachePath === "${{ matrix.app }}/package-lock.json") continue
+      ensurePath(failures, repositoryRoot, cachePath, label)
+      if (!/^(web|admin)\/package-lock\.json$/.test(cachePath)) failures.push(`[cache-isolation] ${label} uses unsupported cache path ${cachePath}`)
+    }
+  }
+  return failures
+}
+
 function workflowJobs(content) {
   const jobsIndex = content.search(/^jobs:\s*$/m)
   if (jobsIndex === -1) return []
@@ -168,7 +209,21 @@ function workflowJobs(content) {
 }
 
 function cacheDependencyPaths(content) {
-  return [...content.matchAll(/^\s+cache-dependency-path:\s*([^\s#]+)\s*$/gm)].map((match) => match[1].replace(/^['"]|['"]$/g, ""))
+  const paths = []
+  for (const match of content.matchAll(/^(\s*)cache-dependency-path:\s*([^\n#]*)\s*$/gm)) {
+    const indent = match[1].length
+    const value = match[2].trim()
+    if (value && value !== "|") paths.push(value.replace(/^['"]|['"]$/g, ""))
+    if (value === "|") {
+      const tail = content.slice((match.index ?? 0) + match[0].length)
+      for (const line of tail.split("\n").slice(1)) {
+        const item = line.match(/^(\s+)(\S.*)$/)
+        if (!item || item[1].length <= indent) break
+        paths.push(item[2].trim())
+      }
+    }
+  }
+  return paths
 }
 
 function ensurePath(failures, repositoryRoot, relativePath, workflow) {

--- a/scripts/check-github-actions.test.mjs
+++ b/scripts/check-github-actions.test.mjs
@@ -2,13 +2,60 @@ import test from "node:test"
 import assert from "node:assert/strict"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
-import { loadWorkflowSet, validateWorkflowSet } from "./check-github-actions.mjs"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import os from "node:os"
+import { loadWorkflowSet, validateSetupNodeCaching, validateWorkflowSet } from "./check-github-actions.mjs"
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
 
 test("accepts the repository GitHub Actions policy", async () => {
   const workflows = await loadWorkflowSet(root)
   assert.deepEqual(validateWorkflowSet(workflows, root), [])
+})
+
+const setupNode = (configuration, context = "") => `${context}
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 22
+${configuration}
+      - name: Next step
+        run: node --version
+`
+
+test("accepts explicit web, admin, two-lockfile and cache-disabled setup-node configurations", () => {
+  const cases = [
+    setupNode("          cache: npm\n          cache-dependency-path: web/package-lock.json", "    defaults:\n      run:\n        working-directory: web"),
+    setupNode("          cache: npm\n          cache-dependency-path: admin/package-lock.json", "    defaults:\n      run:\n        working-directory: admin"),
+    setupNode("          cache: npm\n          cache-dependency-path: |\n            web/package-lock.json\n            admin/package-lock.json", "    run: npm --prefix web ci && npm --prefix admin ci"),
+    setupNode("          package-manager-cache: false"),
+  ]
+  for (const fixture of cases) assert.deepEqual(validateSetupNodeCaching(fixture, root, "fixture"), [])
+})
+
+test("rejects setup-node automatic root caching and enabled caching without a lockfile path", () => {
+  const automatic = validateSetupNodeCaching(setupNode(""), root, "automatic")
+  assert(automatic.some((failure) => failure.startsWith("[setup-node-cache]")))
+  assert(automatic.some((failure) => failure.startsWith("[setup-node-cache-path]")))
+  const missing = validateSetupNodeCaching(setupNode("          cache: npm"), root, "missing path")
+  assert(missing.some((failure) => failure.startsWith("[setup-node-cache-path]")))
+})
+
+test("rejects an application cache pointed at the wrong lockfile", () => {
+  const fixture = setupNode("          cache: npm\n          cache-dependency-path: admin/package-lock.json", "    defaults:\n      run:\n        working-directory: web")
+  assert(validateSetupNodeCaching(fixture, root, "web fixture").some((failure) => failure.includes("must cache web/package-lock.json")))
+})
+
+test("rejects introducing a root package-lock.json", async () => {
+  const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), "scalesmiths-actions-policy-"))
+  try {
+    await writeFile(path.join(temporaryRoot, "package-lock.json"), "{}\n")
+    const workflows = await loadWorkflowSet(root)
+    assert(validateWorkflowSet(workflows, temporaryRoot).some((failure) => failure === "[root-lockfile] the repository must not contain a root package-lock.json"))
+  } finally {
+    await rm(temporaryRoot, { recursive: true, force: true })
+  }
 })
 
 test("rejects a root lockfile cache and silent required-gate skips", async () => {


### PR DESCRIPTION
<!--
Keep this honest and short. Reviewers need evidence, not ceremony.
Delete the guidance comments as you fill each section in.
`npm run check:pr-metadata` runs on every pull request and checks this template
is actually completed. Run it locally with GITHUB_EVENT_PATH set if you want.
-->

## Summary

<!-- What changed, and why. Two or three sentences. Not the branch name. -->

## Type

- [ ] `feat`
- [ ] `fix`
- [ ] `test`
- [ ] `docs`
- [ ] `refactor`
- [ ] `security`
- [ ] `perf`
- [ ] `chore`

## Scope

- [ ] Public web
- [ ] Admin
- [ ] Forge
- [ ] Database/migrations
- [ ] Docker/deployment/Nginx
- [ ] CI/tooling
- [ ] Documentation only

## Validation

Commands run, with results:

```text

```

Commands not run, and why:

```text

```

## Migrations

- [ ] No database migration.
- [ ] Migration included and documented below.

<!-- If a migration is included: order, forward/backward compatibility, rollout notes. -->

## Environment

- [ ] No environment-variable change.
- [ ] Environment variables added to `.env.example` and documented below.

<!-- If variables changed: name, purpose, and which app and environment needs them. -->

## Security and Privacy

- [ ] No secrets, provider credentials, real `.env` files, database dumps, or
      client-private exports are included.
- [ ] Admin/Forge access control and generated-workspace isolation are preserved.
- [ ] Public analytics remains minimised and consent-aware.

<!-- Note anything touching auth, MFA, RBAC, sandboxing, egress, or client data. -->

## Evidence

<!--
Required for visual, operational, or workflow-heavy changes: screenshots, run IDs,
logs, or artifact links. Write "Not applicable" and say why if the change is purely
internal.
-->

## Residual Risk and Follow-up

<!--
What could still bite us, and what is deliberately deferred. Write "None" if there
genuinely is nothing. Do not leave this empty.
-->

## Rollback

<!--
How to undo this safely. Required when the change touches migrations, deployment,
Nginx, auth, or release tooling. Write "Not applicable" otherwise.
-->
